### PR TITLE
Format JSX expression and cloning token

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -566,7 +566,7 @@ namespace ts.formatting {
                 if (tokenInfo.token.end > node.end) {
                     break;
                 }
-                consumeTokenAndAdvanceScanner(tokenInfo, node, nodeDynamicIndentation);
+                consumeTokenAndAdvanceScanner(tokenInfo, node, nodeDynamicIndentation, node);
             }
 
             function processChildNode(
@@ -617,7 +617,7 @@ namespace ts.formatting {
                         break;
                     }
 
-                    consumeTokenAndAdvanceScanner(tokenInfo, node, parentDynamicIndentation);
+                    consumeTokenAndAdvanceScanner(tokenInfo, node, parentDynamicIndentation, node);
                 }
 
                 if (!formattingScanner.isOnToken()) {
@@ -673,11 +673,11 @@ namespace ts.formatting {
                                 computeIndentation(tokenInfo.token, startLine, Constants.Unknown, parent, parentDynamicIndentation, parentStartLine);
 
                             listDynamicIndentation = getDynamicIndentation(parent, parentStartLine, indentation.indentation, indentation.delta);
-                            consumeTokenAndAdvanceScanner(tokenInfo, parent, listDynamicIndentation);
+                            consumeTokenAndAdvanceScanner(tokenInfo, parent, listDynamicIndentation, parent);
                         }
                         else {
                             // consume any tokens that precede the list as child elements of 'node' using its indentation scope
-                            consumeTokenAndAdvanceScanner(tokenInfo, parent, parentDynamicIndentation);
+                            consumeTokenAndAdvanceScanner(tokenInfo, parent, parentDynamicIndentation, parent);
                         }
                     }
                 }
@@ -697,13 +697,13 @@ namespace ts.formatting {
                         // without this check close paren will be interpreted as list end token for function expression which is wrong
                         if (tokenInfo.token.kind === listEndToken && rangeContainsRange(parent, tokenInfo.token)) {
                             // consume list end token
-                            consumeTokenAndAdvanceScanner(tokenInfo, parent, listDynamicIndentation);
+                            consumeTokenAndAdvanceScanner(tokenInfo, parent, listDynamicIndentation, parent);
                         }
                     }
                 }
             }
 
-            function consumeTokenAndAdvanceScanner(currentTokenInfo: TokenInfo, parent: Node, dynamicIndentation: DynamicIndentation, container?: Node): void {
+            function consumeTokenAndAdvanceScanner(currentTokenInfo: TokenInfo, parent: Node, dynamicIndentation: DynamicIndentation, container: Node): void {
                 Debug.assert(rangeContainsRange(parent, currentTokenInfo.token));
 
                 const lastTriviaWasNewLine = formattingScanner.lastTrailingTriviaWasNewLine();

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -496,10 +496,19 @@ namespace ts.formatting {
                         case SyntaxKind.WhileKeyword:
                         case SyntaxKind.AtToken:
                             return indentation;
-                        default:
-                            // if token line equals to the line of containing node (this is a first token in the node) - use node indentation
-                            return nodeStartLine !== line ? indentation + getEffectiveDelta(delta, container) : indentation;
+                        case SyntaxKind.SlashToken:
+                        case SyntaxKind.GreaterThanToken: {
+                            if (container.kind === SyntaxKind.JsxOpeningElement ||
+                                container.kind === SyntaxKind.JsxClosingElement ||
+                                container.kind === SyntaxKind.JsxSelfClosingElement
+                            ) {
+                                return indentation;
+                            }
+                            break;
+                        }
                     }
+                    // if token line equals to the line of containing node (this is a first token in the node) - use node indentation
+                    return nodeStartLine !== line ? indentation + getEffectiveDelta(delta, container) : indentation;
                 },
                 getIndentation: () => indentation,
                 getDelta: child => getEffectiveDelta(delta, child),

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -705,11 +705,18 @@ namespace ts.formatting {
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.ModuleDeclaration:
                 case SyntaxKind.EnumDeclaration:
-                case SyntaxKind.Block:
                 case SyntaxKind.CatchClause:
                 case SyntaxKind.ModuleBlock:
                 case SyntaxKind.SwitchStatement:
                     return true;
+                case SyntaxKind.Block: {
+                    const blockParent = context.currentTokenParent.parent;
+                    if (blockParent.kind !== SyntaxKind.ArrowFunction &&
+                        blockParent.kind !== SyntaxKind.FunctionExpression)
+                    {
+                        return true;
+                    }
+                }
             }
             return false;
         }

--- a/tests/cases/fourslash/formatVariableDeclarationList.ts
+++ b/tests/cases/fourslash/formatVariableDeclarationList.ts
@@ -37,4 +37,4 @@ verify.currentLineContentIs("            x = 'Foo';");
 goTo.marker("11");
 verify.currentLineContentIs("        return fun;");
 goTo.marker("12");
-verify.currentLineContentIs("    } (fun1));");
+verify.currentLineContentIs("    }(fun1));");

--- a/tests/cases/fourslash/formattingJsxElements.ts
+++ b/tests/cases/fourslash/formattingJsxElements.ts
@@ -72,6 +72,8 @@
 ////<span>)   </span>;/*closingParenInJsxElement2*/
 ////<Router        routes      =        { 3 }   /      >;/*jsxExpressionSpaces*/
 ////<Router routes={                (3)    } />;/*jsxExpressionSpaces2*/
+////<Router routes={() => {}}/*jsxExpressionSpaces3*/
+/////>;/*jsxDanglingSelfClosingToken*/
 
 format.document();
 goTo.marker("autoformat");
@@ -120,8 +122,7 @@ goTo.marker("expressionIndent");
 verify.indentationIs(12);
 
 goTo.marker("danglingBracketAutoformat")
-// TODO: verify.currentLineContentIs("    >");
-verify.currentLineContentIs("        >");
+verify.currentLineContentIs("    >");
 goTo.marker("closingTagAutoformat");
 verify.currentLineContentIs("    </div>");
 
@@ -146,3 +147,7 @@ goTo.marker("jsxExpressionSpaces");
 verify.currentLineContentIs("<Router routes={3} />;");
 goTo.marker("jsxExpressionSpaces2");
 verify.currentLineContentIs("<Router routes={(3)} />;");
+goTo.marker("jsxExpressionSpaces3");
+verify.currentLineContentIs("<Router routes={() => { }}");
+goTo.marker("jsxDanglingSelfClosingToken");
+verify.currentLineContentIs("/>;");


### PR DESCRIPTION
Fixes #8663

Input+Fixed:

```ts
<div name="test"
     data="test"
     onClick={() => { }}
>
  <div>test</div>
</div>
```

Current:

```ts
<div name="test"
    onClick={() => { } }
    data="test"
    >
    <div>test</div>
</div>
```